### PR TITLE
Fix: Install ComfyUI requirements.txt to keep frontend updated

### DIFF
--- a/start.5090.sh
+++ b/start.5090.sh
@@ -185,6 +185,10 @@ if [ ! -d "$COMFYUI_DIR" ] || [ ! -d "$VENV_DIR" ]; then
         python -m ensurepip --upgrade
         python -m pip install --upgrade pip
 
+        # Update ComfyUI dependencies (frontend, etc.)
+        echo "Installing ComfyUI requirements..."
+        pip install -r "$COMFYUI_DIR/requirements.txt"
+
         echo "Base packages (torch cu128, numpy, etc.) available from system site-packages"
         echo "Installing custom node dependencies..."
 
@@ -218,6 +222,10 @@ if [ ! -d "$COMFYUI_DIR" ] || [ ! -d "$VENV_DIR" ]; then
 else
     # Just activate the existing venv
     source $VENV_DIR/bin/activate
+
+    # Update ComfyUI dependencies on each start (ensures frontend stays current)
+    echo "Updating ComfyUI dependencies..."
+    pip install -q -r "$COMFYUI_DIR/requirements.txt"
 
     echo "Checking for custom node dependencies..."
 

--- a/start.sh
+++ b/start.sh
@@ -185,6 +185,10 @@ if [ ! -d "$COMFYUI_DIR" ] || [ ! -d "$VENV_DIR" ]; then
         python -m ensurepip --upgrade
         python -m pip install --upgrade pip
 
+        # Update ComfyUI dependencies (frontend, etc.)
+        echo "Installing ComfyUI requirements..."
+        pip install -r "$COMFYUI_DIR/requirements.txt"
+
         echo "Base packages (torch, numpy, etc.) available from system site-packages"
         echo "Installing custom node dependencies..."
 
@@ -218,6 +222,10 @@ if [ ! -d "$COMFYUI_DIR" ] || [ ! -d "$VENV_DIR" ]; then
 else
     # Just activate the existing venv
     source $VENV_DIR/bin/activate
+
+    # Update ComfyUI dependencies on each start (ensures frontend stays current)
+    echo "Updating ComfyUI dependencies..."
+    pip install -q -r "$COMFYUI_DIR/requirements.txt"
 
     echo "Checking for custom node dependencies..."
 


### PR DESCRIPTION
## Summary

The ComfyUI frontend is now distributed as a pip package (`comfyui-frontend-package`) and needs to be installed via `requirements.txt`. Without this, users see warnings on every startup:

```
WARNING WARNING WARNING WARNING WARNING
Installed frontend version 1.34.9 is lower than the recommended version 1.36.13.
Please install the updated requirements.txt file by running:
/workspace/runpod-slim/ComfyUI/.venv/bin/python -m pip install -r /workspace/runpod-slim/ComfyUI/requirements.txt
```

## Changes

- **First-time setup**: Install `requirements.txt` after pip upgrade (before custom node dependencies)
- **Existing installs**: Update `requirements.txt` on each container start (quiet mode with `-q`)

Applied to both `start.sh` and `start.5090.sh`.

## Test Plan

- [ ] Start a fresh pod (no existing venv) - verify no frontend warning
- [ ] Restart an existing pod - verify frontend gets updated silently
- [ ] Verify ComfyUI starts normally after changes

🤖 Generated with [Claude Code](https://claude.ai/code)