### PR TITLE
  ComfyUI update to v0.17.2, CUDA 12.4-12.8 universal compat, venv migration, crash resilience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
     sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
     mkdir -p /run/sshd && \
-    ssh-keygen -A
+    rm -f /etc/ssh/ssh_host_*
 
 # Create workspace directory
 RUN mkdir -p /workspace/runpod-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,8 @@ RUN cat ComfyUI/requirements.txt > requirements.in && \
     echo "GitPython" >> requirements.in && \
     echo "opencv-python" >> requirements.in && \
     echo "jupyter" >> requirements.in && \
+    echo "jupyter-resource-usage" >> requirements.in && \
+    echo "jupyterlab-nvdashboard" >> requirements.in && \
     echo "torch==${TORCH_VERSION}" >> constraints.txt && \
     echo "torchvision==${TORCHVISION_VERSION}" >> constraints.txt && \
     echo "torchaudio==${TORCHAUDIO_VERSION}" >> constraints.txt && \
@@ -169,6 +171,11 @@ COPY --from=builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/share/jupyter /usr/local/share/jupyter
 
+# Register Jupyter extensions (pip --ignore-installed skips post-install hooks)
+RUN mkdir -p /usr/local/etc/jupyter/jupyter_server_config.d && \
+    echo '{"ServerApp":{"jpserver_extensions":{"jupyter_server_terminals":true,"jupyterlab":true,"jupyter_resource_usage":true,"jupyterlab_nvdashboard":true}}}' \
+    > /usr/local/etc/jupyter/jupyter_server_config.d/extensions.json
+
 # Copy baked ComfyUI + custom nodes from builder stage
 COPY --from=builder /opt/comfyui-baked /opt/comfyui-baked
 
@@ -186,13 +193,19 @@ RUN curl -fSL "https://github.com/filebrowser/filebrowser/releases/download/${FI
 ENV PATH=/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
 
+# Allow container to start on hosts with older CUDA 12.x drivers
+ENV NVIDIA_REQUIRE_CUDA=""
+ENV NVIDIA_DISABLE_REQUIRE=true
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
 # Jupyter is included in the lock file and installed in the builder stage
 
 # Configure SSH for root login
 RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
     sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config && \
     mkdir -p /run/sshd && \
-    rm -f /etc/ssh/ssh_host_*
+    ssh-keygen -A
 
 # Create workspace directory
 RUN mkdir -p /workspace/runpod-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -197,7 +197,7 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
 ENV NVIDIA_REQUIRE_CUDA=""
 ENV NVIDIA_DISABLE_REQUIRE=true
 ENV NVIDIA_VISIBLE_DEVICES=all
-ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV NVIDIA_DRIVER_CAPABILITIES=all
 
 # Jupyter is included in the lock file and installed in the builder stage
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -4,19 +4,19 @@ variable "TAG" {
 
 # === Version Pins (single source of truth) ===
 variable "COMFYUI_VERSION" {
-  default = "v0.14.2"
+  default = "v0.17.2"
 }
 variable "MANAGER_SHA" {
-  default = "f41365abe957"
+  default = "c94236a61457"
 }
 variable "KJNODES_SHA" {
-  default = "9086a8dfb665"
+  default = "6dfca48e00a5"
 }
 variable "CIVICOMFY_SHA" {
   default = "555e984bbcb0"
 }
 variable "RUNPODDIRECT_SHA" {
-  default = "f7cc02cccb49"
+  default = "4de8269b5181"
 }
 # Regular image (cu128)
 variable "TORCH_VERSION" {

--- a/scripts/fetch-hashes.sh
+++ b/scripts/fetch-hashes.sh
@@ -3,14 +3,13 @@
 # Prints HCL-formatted output for copy-paste into docker-bake.hcl.
 #
 # Usage:
-#   ./scripts/fetch-hashes.sh              # uses unauthenticated API
-#   GITHUB_TOKEN=ghp_xxx ./scripts/fetch-hashes.sh  # authenticated (higher rate limit)
+#   ./scripts/fetch-hashes.sh
+#   GITHUB_TOKEN=ghp_xxx ./scripts/fetch-hashes.sh  # higher rate limit
 #
 # Works on both Linux (bash 4+) and macOS (bash 3.2).
 
 set -euo pipefail
 
-# --- Config: repo|variable pairs (no associative arrays — macOS compat) ---
 NODES="
 ltdrdata/ComfyUI-Manager|MANAGER_SHA
 kijai/ComfyUI-KJNodes|KJNODES_SHA
@@ -18,7 +17,6 @@ MoonGoblinDev/Civicomfy|CIVICOMFY_SHA
 MadiatorLabs/ComfyUI-RunpodDirect|RUNPODDIRECT_SHA
 "
 
-# --- Resolve paths ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BAKE_FILE="$SCRIPT_DIR/../docker-bake.hcl"
 
@@ -27,42 +25,29 @@ if [[ ! -f "$BAKE_FILE" ]]; then
   exit 1
 fi
 
-# --- Auth header (optional) ---
-AUTH_ARGS=""
-if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-  AUTH_ARGS="-H Authorization: Bearer $GITHUB_TOKEN"
-fi
-
-# --- Read current hash from bake file ---
 get_current_hash() {
   local var_name="$1"
   grep -A2 "variable \"${var_name}\"" "$BAKE_FILE" | sed -n 's/.*default *= *"\([^"]*\)".*/\1/p' | head -1 || echo "unknown"
 }
 
-# --- Fetch latest commit SHA (short, 12 chars) ---
 fetch_latest_sha() {
   local repo="$1"
   local response
-  if [[ -n "$AUTH_ARGS" ]]; then
-    response=$(curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
-      -H "Accept: application/vnd.github.v3+json" \
-      "https://api.github.com/repos/${repo}/commits?per_page=1" 2>/dev/null) || { echo "ERROR"; return; }
-  else
-    response=$(curl -fsSL \
-      -H "Accept: application/vnd.github.v3+json" \
-      "https://api.github.com/repos/${repo}/commits?per_page=1" 2>/dev/null) || { echo "ERROR"; return; }
+  local auth_args=""
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    auth_args="-H Authorization: Bearer $GITHUB_TOKEN"
   fi
+  response=$(curl -fsSL $auth_args \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/${repo}/commits?per_page=1" 2>/dev/null) || { echo "ERROR"; return; }
   echo "$response" | sed -n 's/.*"sha" *: *"\([a-f0-9]\{12\}\).*/\1/p' | head -1
 }
 
-# --- Main ---
 echo "# Updated custom node hashes ($(date +%Y-%m-%d))"
 echo "# Paste these into docker-bake.hcl to update"
 echo ""
 
-has_changes=false
-
-echo "$NODES" | while IFS='|' read -r repo var_name; do
+while IFS='|' read -r repo var_name; do
   [[ -z "$repo" ]] && continue
 
   current=$(get_current_hash "$var_name")
@@ -84,7 +69,7 @@ echo "$NODES" | while IFS='|' read -r repo var_name; do
   echo "variable \"${var_name}\" {"
   echo "  default = \"${latest}\""
   echo "}"
-done
+done <<< "$NODES"
 
 echo ""
 echo "# ^ Copy the variable blocks above into docker-bake.hcl"

--- a/scripts/fetch-hashes.sh
+++ b/scripts/fetch-hashes.sh
@@ -5,16 +5,18 @@
 # Usage:
 #   ./scripts/fetch-hashes.sh              # uses unauthenticated API
 #   GITHUB_TOKEN=ghp_xxx ./scripts/fetch-hashes.sh  # authenticated (higher rate limit)
+#
+# Works on both Linux (bash 4+) and macOS (bash 3.2).
 
 set -euo pipefail
 
-# --- Config: repo -> variable name ---
-declare -A REPOS=(
-  ["ltdrdata/ComfyUI-Manager"]="MANAGER_SHA"
-  ["kijai/ComfyUI-KJNodes"]="KJNODES_SHA"
-  ["MoonGoblinDev/Civicomfy"]="CIVICOMFY_SHA"
-  ["MadiatorLabs/ComfyUI-RunpodDirect"]="RUNPODDIRECT_SHA"
-)
+# --- Config: repo|variable pairs (no associative arrays — macOS compat) ---
+NODES="
+ltdrdata/ComfyUI-Manager|MANAGER_SHA
+kijai/ComfyUI-KJNodes|KJNODES_SHA
+MoonGoblinDev/Civicomfy|CIVICOMFY_SHA
+MadiatorLabs/ComfyUI-RunpodDirect|RUNPODDIRECT_SHA
+"
 
 # --- Resolve paths ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,12 +28,12 @@ if [[ ! -f "$BAKE_FILE" ]]; then
 fi
 
 # --- Auth header (optional) ---
-AUTH_HEADER=()
+AUTH_ARGS=""
 if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-  AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  AUTH_ARGS="-H Authorization: Bearer $GITHUB_TOKEN"
 fi
 
-# --- Read current hash from bake file (variable block spans multiple lines) ---
+# --- Read current hash from bake file ---
 get_current_hash() {
   local var_name="$1"
   grep -A2 "variable \"${var_name}\"" "$BAKE_FILE" | sed -n 's/.*default *= *"\([^"]*\)".*/\1/p' | head -1 || echo "unknown"
@@ -41,11 +43,15 @@ get_current_hash() {
 fetch_latest_sha() {
   local repo="$1"
   local response
-  response=$(curl -fsSL "${AUTH_HEADER[@]}" \
-    -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${repo}/commits?per_page=1" 2>/dev/null) || {
-    echo "ERROR" ; return
-  }
+  if [[ -n "$AUTH_ARGS" ]]; then
+    response=$(curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${repo}/commits?per_page=1" 2>/dev/null) || { echo "ERROR"; return; }
+  else
+    response=$(curl -fsSL \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${repo}/commits?per_page=1" 2>/dev/null) || { echo "ERROR"; return; }
+  fi
   echo "$response" | sed -n 's/.*"sha" *: *"\([a-f0-9]\{12\}\).*/\1/p' | head -1
 }
 
@@ -56,8 +62,9 @@ echo ""
 
 has_changes=false
 
-for repo in "${!REPOS[@]}"; do
-  var_name="${REPOS[$repo]}"
+echo "$NODES" | while IFS='|' read -r repo var_name; do
+  [[ -z "$repo" ]] && continue
+
   current=$(get_current_hash "$var_name")
   latest=$(fetch_latest_sha "$repo")
 
@@ -73,7 +80,6 @@ for repo in "${!REPOS[@]}"; do
     echo "# ${var_name}: ${current} (unchanged)"
   else
     echo "# ${var_name}: ${current} -> ${latest} (CHANGED)"
-    has_changes=true
   fi
   echo "variable \"${var_name}\" {"
   echo "  default = \"${latest}\""
@@ -81,8 +87,4 @@ for repo in "${!REPOS[@]}"; do
 done
 
 echo ""
-if [[ "$has_changes" == true ]]; then
-  echo "# ^ Copy the variable blocks above into docker-bake.hcl"
-else
-  echo "# All hashes are up to date."
-fi
+echo "# ^ Copy the variable blocks above into docker-bake.hcl"

--- a/scripts/fetch-hashes.sh
+++ b/scripts/fetch-hashes.sh
@@ -33,13 +33,18 @@ get_current_hash() {
 fetch_latest_sha() {
   local repo="$1"
   local response
-  local auth_args=""
-  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-    auth_args="-H Authorization: Bearer $GITHUB_TOKEN"
+  local auth_header=""
+  [[ -n "${GITHUB_TOKEN:-}" ]] && auth_header="Authorization: Bearer $GITHUB_TOKEN"
+
+  if [[ -n "$auth_header" ]]; then
+    response=$(curl -fsSL -H "$auth_header" \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${repo}/commits?per_page=1" 2>/dev/null) || { echo "ERROR"; return; }
+  else
+    response=$(curl -fsSL \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${repo}/commits?per_page=1" 2>/dev/null) || { echo "ERROR"; return; }
   fi
-  response=$(curl -fsSL $auth_args \
-    -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${repo}/commits?per_page=1" 2>/dev/null) || { echo "ERROR"; return; }
   echo "$response" | sed -n 's/.*"sha" *: *"\([a-f0-9]\{12\}\).*/\1/p' | head -1
 }
 

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,7 @@ set -e  # Exit the script if any statement returns a non-true return value
 
 COMFYUI_DIR="/workspace/runpod-slim/ComfyUI"
 VENV_DIR="$COMFYUI_DIR/.venv-cu128"
+OLD_VENV_DIR="$COMFYUI_DIR/.venv"
 FILEBROWSER_CONFIG="/root/.config/filebrowser/config.json"
 DB_FILE="/workspace/runpod-slim/filebrowser.db"
 
@@ -14,14 +15,9 @@ DB_FILE="/workspace/runpod-slim/filebrowser.db"
 setup_ssh() {
     mkdir -p ~/.ssh
     
-    # Generate host keys if they don't exist
-    for type in rsa dsa ecdsa ed25519; do
-        if [ ! -f "/etc/ssh/ssh_host_${type}_key" ]; then
-            ssh-keygen -t ${type} -f "/etc/ssh/ssh_host_${type}_key" -q -N ''
-            echo "${type^^} key fingerprint:"
-            ssh-keygen -lf "/etc/ssh/ssh_host_${type}_key.pub"
-        fi
-    done
+    if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
+        ssh-keygen -A -q
+    fi
 
     # If PUBLIC_KEY is provided, use it
     if [[ $PUBLIC_KEY ]]; then
@@ -140,6 +136,40 @@ if [ ! -f "$ARGS_FILE" ]; then
     echo "Created empty ComfyUI arguments file at $ARGS_FILE"
 fi
 
+# Migrate old CUDA 12.4 venv to cu128
+if [ -d "$OLD_VENV_DIR" ] && [ ! -d "$VENV_DIR" ]; then
+    NODE_COUNT=$(find "$COMFYUI_DIR/custom_nodes" -maxdepth 2 -name "requirements.txt" 2>/dev/null | wc -l)
+    echo "============================================="
+    echo "  CUDA 12.4 -> 12.8 migration"
+    echo "  Reinstalling deps for $NODE_COUNT custom nodes"
+    echo "  This may take several minutes"
+    echo "============================================="
+    rm -rf "$OLD_VENV_DIR"
+    cd "$COMFYUI_DIR"
+    python3.12 -m venv --system-site-packages "$VENV_DIR"
+    source "$VENV_DIR/bin/activate"
+    python -m ensurepip
+    # Skip nodes baked into the image — their deps are in system site-packages
+    BAKED_NODES="ComfyUI-Manager ComfyUI-KJNodes Civicomfy ComfyUI-RunpodDirect"
+    CURRENT=0
+    INSTALLED=0
+    for req in "$COMFYUI_DIR"/custom_nodes/*/requirements.txt; do
+        if [ -f "$req" ]; then
+            NODE_NAME=$(basename "$(dirname "$req")")
+            case " $BAKED_NODES " in
+                *" $NODE_NAME "*) continue ;;
+            esac
+            CURRENT=$((CURRENT + 1))
+            echo "[$CURRENT] $NODE_NAME"
+            pip install -r "$req" 2>&1 | grep -E "^(Successfully|ERROR)" || true
+            INSTALLED=$((INSTALLED + 1))
+        fi
+    done
+    echo "Upgrading ComfyUI requirements..."
+    pip install --upgrade -r "$COMFYUI_DIR/requirements.txt" 2>&1 | grep -E "^(Successfully|ERROR)" || true
+    echo "Migration complete — $INSTALLED user nodes processed (${NODE_COUNT} total, baked nodes skipped)"
+fi
+
 # Setup ComfyUI if needed
 if [ ! -d "$COMFYUI_DIR" ] || [ ! -d "$VENV_DIR" ]; then
     echo "First time setup: Copying baked ComfyUI to workspace..."
@@ -171,21 +201,26 @@ fi
 # Warm up pip so ComfyUI-Manager's 5s timeout check doesn't fail on cold start
 python -m pip --version > /dev/null 2>&1
 
-# Start ComfyUI in foreground (exec replaces shell → proper signal handling, logs to stdout)
+# Start ComfyUI — keep container alive if it crashes so SSH/Jupyter remain accessible
 cd $COMFYUI_DIR
 FIXED_ARGS="--listen 0.0.0.0 --port 8188"
 if [ -s "$ARGS_FILE" ]; then
-    # File exists and is not empty, combine fixed args with custom args
     CUSTOM_ARGS=$(grep -v '^#' "$ARGS_FILE" | tr '\n' ' ')
     if [ ! -z "$CUSTOM_ARGS" ]; then
-        echo "Starting ComfyUI with additional arguments: $CUSTOM_ARGS"
-        exec python main.py $FIXED_ARGS $CUSTOM_ARGS
-    else
-        echo "Starting ComfyUI with default arguments"
-        exec python main.py $FIXED_ARGS
+        FIXED_ARGS="$FIXED_ARGS $CUSTOM_ARGS"
     fi
-else
-    # File is empty, use only fixed args
-    echo "Starting ComfyUI with default arguments"
-    exec python main.py $FIXED_ARGS
 fi
+
+echo "Starting ComfyUI with args: $FIXED_ARGS"
+python main.py $FIXED_ARGS || true
+
+echo "============================================="
+echo "  ComfyUI crashed — check the logs above."
+echo "  SSH and JupyterLab are still available."
+echo "  To restart after fixing:"
+echo "    cd $COMFYUI_DIR && source .venv-cu128/bin/activate"
+echo "    python main.py $FIXED_ARGS"
+echo "============================================="
+
+# Keep container alive for debugging
+sleep infinity

--- a/start.sh
+++ b/start.sh
@@ -144,7 +144,7 @@ if [ -d "$OLD_VENV_DIR" ] && [ ! -d "$VENV_DIR" ]; then
     echo "  Reinstalling deps for $NODE_COUNT custom nodes"
     echo "  This may take several minutes"
     echo "============================================="
-    rm -rf "$OLD_VENV_DIR"
+    mv "$OLD_VENV_DIR" "${OLD_VENV_DIR}.bak"
     cd "$COMFYUI_DIR"
     python3.12 -m venv --system-site-packages "$VENV_DIR"
     source "$VENV_DIR/bin/activate"
@@ -168,6 +168,8 @@ if [ -d "$OLD_VENV_DIR" ] && [ ! -d "$VENV_DIR" ]; then
     echo "Upgrading ComfyUI requirements..."
     pip install --upgrade -r "$COMFYUI_DIR/requirements.txt" 2>&1 | grep -E "^(Successfully|ERROR)" || true
     echo "Migration complete — $INSTALLED user nodes processed (${NODE_COUNT} total, baked nodes skipped)"
+    echo "Old venv backed up at ${OLD_VENV_DIR}.bak — delete it to free space:"
+    echo "  rm -rf ${OLD_VENV_DIR}.bak"
 fi
 
 # Setup ComfyUI if needed
@@ -212,7 +214,10 @@ if [ -s "$ARGS_FILE" ]; then
 fi
 
 echo "Starting ComfyUI with args: $FIXED_ARGS"
-python main.py $FIXED_ARGS || true
+python main.py $FIXED_ARGS &
+COMFY_PID=$!
+trap "kill $COMFY_PID 2>/dev/null" SIGTERM SIGINT
+wait $COMFY_PID || true
 
 echo "============================================="
 echo "  ComfyUI crashed — check the logs above."
@@ -222,5 +227,4 @@ echo "    cd $COMFYUI_DIR && source .venv-cu128/bin/activate"
 echo "    python main.py $FIXED_ARGS"
 echo "============================================="
 
-# Keep container alive for debugging
 sleep infinity


### PR DESCRIPTION
Changes:

  - Update ComfyUI v0.14.2 -> v0.17.2
  - Update custom node SHAs (Manager, KJNodes, RunpodDirect)
  - Add NVIDIA_DISABLE_REQUIRE for CUDA 12.4-12.8 host support
  - Add .venv -> .venv-cu128 migration with custom node dep reinstall
  - Keep container alive on ComfyUI crash (SSH/Jupyter stay accessible)
  - Add jupyter-resource-usage and jupyterlab-nvdashboard
  - Pre-generate SSH host keys at build time
  - macOS compatible fetch-hashes.sh