### PR TITLE
Update ComfyUI to v0.18.2 + CRF Fix + RunpodDirect Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,12 +82,7 @@ RUN cd /tmp/build/ComfyUI && \
     git init && git add -A && git -c user.name=- -c user.email=- commit -q -m "ComfyUI-RunpodDirect ${RUNPODDIRECT_SHA}" && \
     git remote add origin https://github.com/MadiatorLabs/ComfyUI-RunpodDirect.git
 
-# Install PyTorch (pinned version)
-RUN python3.12 -m pip install --no-cache-dir \
-    torch==${TORCH_VERSION} torchvision==${TORCHVISION_VERSION} torchaudio==${TORCHAUDIO_VERSION} \
-    --index-url https://download.pytorch.org/whl/${TORCH_INDEX_SUFFIX}
-
-# Generate lock file from all requirements, then install with hash verification
+# Generate lock file from all requirements (including torch pins), then install with hash verification
 WORKDIR /tmp/build
 RUN cat ComfyUI/requirements.txt > requirements.in && \
     for node_dir in ComfyUI/custom_nodes/*/; do \
@@ -104,8 +99,15 @@ RUN cat ComfyUI/requirements.txt > requirements.in && \
     echo "torchvision==${TORCHVISION_VERSION}" >> constraints.txt && \
     echo "torchaudio==${TORCHAUDIO_VERSION}" >> constraints.txt && \
     echo "pillow>=12.1.1" >> constraints.txt && \
-    PIP_CONSTRAINT=constraints.txt pip-compile --generate-hashes --output-file=requirements.lock --strip-extras --allow-unsafe requirements.in && \
-    python3.12 -m pip install --no-cache-dir --ignore-installed --require-hashes -r requirements.lock
+    TORCH_INDEX_URL="https://download.pytorch.org/whl/${TORCH_INDEX_SUFFIX}" && \
+    PIP_INDEX_URL=https://pypi.org/simple \
+    PIP_EXTRA_INDEX_URL="${TORCH_INDEX_URL}" \
+    PIP_CONSTRAINT=constraints.txt \
+    pip-compile --generate-hashes --output-file=requirements.lock --strip-extras --allow-unsafe requirements.in && \
+    python3.12 -m pip install --no-cache-dir --ignore-installed --require-hashes \
+    --index-url https://pypi.org/simple \
+    --extra-index-url "${TORCH_INDEX_URL}" \
+    -r requirements.lock
 
 # Pre-populate ComfyUI-Manager cache so first cold start skips the slow registry fetch
 COPY scripts/prebake-manager-cache.py /tmp/prebake-manager-cache.py

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -4,13 +4,13 @@ variable "TAG" {
 
 # === Version Pins (single source of truth) ===
 variable "COMFYUI_VERSION" {
-  default = "v0.17.2"
+  default = "v0.18.2"
 }
 variable "MANAGER_SHA" {
-  default = "c94236a61457"
+  default = "bbafbb1290f0"
 }
 variable "KJNODES_SHA" {
-  default = "6dfca48e00a5"
+  default = "068d4fee62d3"
 }
 variable "CIVICOMFY_SHA" {
   default = "555e984bbcb0"
@@ -20,23 +20,23 @@ variable "RUNPODDIRECT_SHA" {
 }
 # Regular image (cu128)
 variable "TORCH_VERSION" {
-  default = "2.10.0"
+  default = "2.10.0+cu128"
 }
 variable "TORCHVISION_VERSION" {
-  default = "0.25.0"
+  default = "0.25.0+cu128"
 }
 variable "TORCHAUDIO_VERSION" {
-  default = "2.10.0"
+  default = "2.10.0+cu128"
 }
 # 5090 image (cu130) — can diverge from regular when needed
 variable "TORCH_VERSION_5090" {
-  default = "2.10.0"
+  default = "2.10.0+cu130"
 }
 variable "TORCHVISION_VERSION_5090" {
-  default = "0.25.0"
+  default = "0.25.0+cu130"
 }
 variable "TORCHAUDIO_VERSION_5090" {
-  default = "2.10.0"
+  default = "2.10.0+cu130"
 }
 variable "FILEBROWSER_VERSION" {
   default = "v2.59.0"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,7 +16,7 @@ variable "CIVICOMFY_SHA" {
   default = "555e984bbcb0"
 }
 variable "RUNPODDIRECT_SHA" {
-  default = "4de8269b5181"
+  default = "6f3a08b8b79c"
 }
 # Regular image (cu128)
 variable "TORCH_VERSION" {

--- a/start.sh
+++ b/start.sh
@@ -205,7 +205,7 @@ python -m pip --version > /dev/null 2>&1
 
 # Start ComfyUI — keep container alive if it crashes so SSH/Jupyter remain accessible
 cd $COMFYUI_DIR
-FIXED_ARGS="--listen 0.0.0.0 --port 8188"
+FIXED_ARGS="--listen 0.0.0.0 --port 8188 --enable-cors-header"
 if [ -s "$ARGS_FILE" ]; then
     CUSTOM_ARGS=$(grep -v '^#' "$ARGS_FILE" | tr '\n' ' ')
     if [ ! -z "$CUSTOM_ARGS" ]; then


### PR DESCRIPTION
Changes:
- ComfyUI updated to v0.18.2
- CRF Fix for new security added by ComfyUI (now user can use links from Runpod console)
- Updated hashes for custom nodes

RunpodDirect changes: https://github.com/MadiatorLabs/ComfyUI-RunpodDirect/commit/6f3a08b8b79ce24d192e3033878a33492b9e178d
- Improved model downloader (now checks for corupted files, detects models from workflows descriptions)
- Added new button that allows access to new settings (now with Runpod branding)
- Added tool that prevents ComfyUI Frontend from disconnecting on idle (100s Cloudlfare timeout)
- Added monkey patch that fixes how ComfyUI sees availible RAM no more OOM errors (Now ComfyUI sees correct RAM from cgroups)


