### PR TITLE
feat: add FILEBROWSER_PASSWORD env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Run the latest ComfyUI. All dependencies are pre-installed in the image. On firs
 ## Access
 
 - `8188`: ComfyUI web UI
-- `8080`: FileBrowser (admin / adminadmin12)
+- `8080`: FileBrowser (admin / `FILEBROWSER_PASSWORD`, default: `adminadmin12`)
 - `8888`: JupyterLab (token via `JUPYTER_PASSWORD`, root at `/workspace`)
 - `22`: SSH (set `PUBLIC_KEY` or check logs for generated root password)
 

--- a/start.sh
+++ b/start.sh
@@ -118,7 +118,7 @@ if [ ! -f "$DB_FILE" ]; then
     filebrowser config set --port 8080
     filebrowser config set --root /workspace
     filebrowser config set --auth.method=json
-    filebrowser users add admin adminadmin12 --perm.admin
+    filebrowser users add admin "${FILEBROWSER_PASSWORD:-adminadmin12}" --perm.admin
 else
     echo "Using existing FileBrowser configuration..."
 fi


### PR DESCRIPTION
Allow overriding the default FileBrowser admin password via FILEBROWSER_PASSWORD env var. Defaults to adminadmin12 when not set.